### PR TITLE
Optionally ignore the number of replicas when syncing Deployments

### DIFF
--- a/charts/kubeit-app-of-apps/Chart.yaml
+++ b/charts/kubeit-app-of-apps/Chart.yaml
@@ -3,5 +3,5 @@ apiVersion: v2
 name: kubeit-app-of-apps
 description: KubeIT ArgoCD app-of-apps chart
 type: application
-version: 0.1.30
+version: 0.1.31
 appVersion: 0.1.0

--- a/charts/kubeit-app-of-apps/templates/applications.yaml
+++ b/charts/kubeit-app-of-apps/templates/applications.yaml
@@ -124,6 +124,13 @@ spec:
           tenantName: "{{ $.Values.tenantName }}"
           environmentName: "{{ $.Values.env }}"
           tenantPodIdentityName: "{{ $.Values.tenantPodIdentityName }}"
+  {{- if ($app.ignoreReplicasOnSync | default false) }}
+  ignoreDifferences:
+  - group: "apps"
+    kind: "Deployment"
+    jsonPointers:
+    - /spec/replicas
+  {{- end }}
   syncPolicy:
     automated:
       prune: true
@@ -133,6 +140,7 @@ spec:
       - CreateNamespace=false
       - PrunePropagationPolicy=foreground
       - PruneLast=false
+      {{if ($app.ignoreReplicasOnSync | default false) }}- RespectIgnoreDifferences{{ end }}
     retry:
       limit: 2
       backoff:

--- a/charts/kubeit-app-of-apps/values.yaml
+++ b/charts/kubeit-app-of-apps/values.yaml
@@ -24,3 +24,4 @@ applications:
   #     path: ""                        # Optional - if git repo was provided as repoURL, provide path to the helm chart in git repo
   #     ignoreMissingValueFiles: false  # Optional - set to true if you want to ignore missing values files (define only required ones), false by default
   #     skipCrds: false                 # Optional - set to true if you want to skip CRDs deployment by Helm, false by default
+  #   ignoreReplicasOnSync: false       # Optional - set to true if you want ArgoCD to ignore the number of replicas when syncing. Useful if you're using HPA.


### PR DESCRIPTION
This change allows an individual app to tell ArgoCD to ignore the replica count when syncing. This is needed when the number of replicas is controlled automatically - e.g. by [HPA](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/), rather than by a value in the chart.

This uses `ignoreDifferences`, but only for the `replicas` value in Deployments. You may wish to make the `ignoreDifferences` section more configurable, rather than accepting this change.

Fixes #12 