### PR TITLE
Allow ArgoCD instance label

### DIFF
--- a/charts/kubeit-app-of-apps/templates/applications.yaml
+++ b/charts/kubeit-app-of-apps/templates/applications.yaml
@@ -58,7 +58,7 @@
 {{- end }}
 {{- end }}
 {{- end }}
-{{- $appTruncName := printf "%s-%s-%s" ($app.name | trunc 20 | trimSuffix "-") (. | trunc 20 | trimSuffix "-") $.Values.clusterSubdomain | trunc 53 | trimSuffix "-" -}}
+{{- $appTruncName := printf "%s-%s" ($app.name | trunc 39 | trimSuffix "-") $.Values.clusterSubdomain | trunc 51 | trimSuffix "-" -}}
 
 ---
 apiVersion: argoproj.io/v1alpha1

--- a/charts/kubeit-app-of-apps/templates/applications.yaml
+++ b/charts/kubeit-app-of-apps/templates/applications.yaml
@@ -58,7 +58,7 @@
 {{- end }}
 {{- end }}
 {{- end }}
-{{- $appTruncName := printf "%s-%s" ($app.name | trunc 39 | trimSuffix "-") $.Values.clusterSubdomain | trunc 51 | trimSuffix "-" -}}
+{{- $appTruncName := printf "%s-%s" ($app.name | trunc 31 | trimSuffix "-") $.Values.clusterSubdomain | trunc 51 | trimSuffix "-" -}}
 
 ---
 apiVersion: argoproj.io/v1alpha1

--- a/charts/kubeit-app-of-apps/templates/applications.yaml
+++ b/charts/kubeit-app-of-apps/templates/applications.yaml
@@ -58,7 +58,7 @@
 {{- end }}
 {{- end }}
 {{- end }}
-{{- $appTruncName := printf "%s-%s" ($app.name | trunc 31 | trimSuffix "-") $.Values.clusterSubdomain | trunc 51 | trimSuffix "-" -}}
+{{- $appTruncName := printf "%s-%s" ($app.name | trunc 31 | trimSuffix "-") $.Values.clusterSubdomain | trunc 43 | trimSuffix "-" -}}
 
 ---
 apiVersion: argoproj.io/v1alpha1


### PR DESCRIPTION
ArgoCD computes instance label as namespace + "_" + argoCD app name with max 63 chars.
"management-\<tenant\>" is 20 chars -> remaining 43 chars for application name (release name).
clusterSuffix (e.g. "-nonprod007" is 12 charts) -> remaining for app name is 31 chars
